### PR TITLE
Add build instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.github
+target

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM balenalib/rpi-alpine:latest
+COPY ./bin/armv7-unknown-linux-musleabihf/hueflow-rs /usr/local/bin/hueflow-rs
+CMD ["hueflow-rs"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # hueflow.rs
 
-Just an excuse to write some rust.
+An autopilot for my home lights based on the time of day.
+Meant to run 24/7 on a Raspberry PI.
+
+## Build instructions
+
+```sh
+cross build --target=armv7-unknown-linux-musleabihf --release
+mkdir -p ./bin/armv7-unknown-linux-musleabihf/
+cp ./target/armv7-unknown-linux-musleabihf/release/hueflow-rs ./bin/armv7-unknown-linux-musleabihf/
+docker build -t demerzel3/hueflow-rs .
+docker push demerzel3/hueflow-rs:latest
+```


### PR DESCRIPTION
Adds some build instructions to the readme and related files to allow building for Raspberry PI.